### PR TITLE
force float on nan remover

### DIFF
--- a/pyjoyplot/__init__.py
+++ b/pyjoyplot/__init__.py
@@ -106,7 +106,7 @@ class _pyjoyplotter():
 				self.data[self.hue] == c]
 
 			x_d = df.loc[df[self.hue] == c, self.x].values
-			x_d = x_d[~np.isnan(x_d)]
+			x_d = x_d[~np.isnan(x_d.astype("float"))]
 
 			col = self.colours[i % self.n_c]
 			if self.weights[i]:


### PR DESCRIPTION
I got the error: 
TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''.
because the column happened to be of type str, even if it was a column of ints. matplotlib will pick this up can convert in its histogram anyway so it isn't an issue if the column is of type str. Alternatively, a try except could be made, so that this error is a little more intuitive.